### PR TITLE
`assert` and `require` replacement

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "org.jetbrains.academy.test.system"
-version = "2.0.8"
+version = "2.1.0"
 
 allprojects {
     apply {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,12 +7,20 @@ plugins {
 }
 
 group = "org.jetbrains.academy.test.system"
-version = "2.0.7"
+version = "2.0.8"
 
 allprojects {
     apply {
         plugin("kotlin")
         plugin("io.gitlab.arturbosch.detekt")
+    }
+
+    dependencies {
+        val junitJupiterVersion = "5.9.0"
+        implementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
+        testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
+        testImplementation("org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion")
+        testRuntimeOnly("org.junit.platform:junit-platform-console:1.9.2")
     }
 
     repositories {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,11 +3,6 @@ version = rootProject.version
 
 dependencies {
     implementation(kotlin("reflect"))
-    val junitJupiterVersion = "5.9.0"
-    implementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion")
-    testRuntimeOnly("org.junit.platform:junit-platform-console:1.9.2")
 }
 
 tasks.test {

--- a/core/src/main/kotlin/org/jetbrains/academy/test/system/core/ClassUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/academy/test/system/core/ClassUtils.kt
@@ -4,6 +4,7 @@ import org.jetbrains.academy.test.system.core.models.Visibility
 import org.jetbrains.academy.test.system.core.models.classes.ClassType
 import org.jetbrains.academy.test.system.core.models.classes.TestClass
 import org.jetbrains.academy.test.system.core.models.getVisibility
+import org.junit.jupiter.api.Assertions
 import java.lang.reflect.Modifier
 import kotlin.jvm.internal.DefaultConstructorMarker
 
@@ -51,24 +52,27 @@ fun Class<*>.checkIfIsDataClass(testClass: TestClass) {
         "toString",
     )
     dataClassMethods.forEach { dataClassMethod ->
-        assert(dataClassMethod in methodsNames || methodsNames.any { dataClassMethod in it }) { "${testClass.getFullName()} must be a data class" }
+        Assertions.assertTrue(
+            dataClassMethod in methodsNames || methodsNames.any { dataClassMethod in it },
+            "${testClass.getFullName()} must be a data class"
+        )
     }
     val componentN = testClass.declaredFields.filter { it.isInPrimaryConstructor && it.visibility == Visibility.PUBLIC }
     val componentNFunctions = methodsNames.filter { "component" in it }
     val componentNErrorMessage =
         "You must put only ${componentN.size} public fields into the primary constructor: ${componentN.joinToString(", ") { it.name }}."
-    assert(componentNFunctions.size == componentN.size) { componentNErrorMessage }
+    Assertions.assertEquals(componentNFunctions.size, componentN.size, componentNErrorMessage)
     componentN.forEachIndexed { index, _ ->
         val name = "component${index + 1}"
-        assert(name in methodsNames || methodsNames.any { name in it }) { componentNErrorMessage }
+        Assertions.assertTrue(name in methodsNames || methodsNames.any { name in it }, componentNErrorMessage)
     }
     val primary = testClass.declaredFields.filter { it.isInPrimaryConstructor }
     val constructorErrorMessage =
         "You must put only ${primary.size} fields into the primary constructor: ${primary.joinToString(", ") { it.name }}."
-    require(this.constructors.isNotEmpty()) { "The data class must have at least one constructor!" }
-    assert(this.constructors.any { constructor ->
+    Assertions.assertTrue(this.constructors.isNotEmpty(), "The data class must have at least one constructor!" )
+    Assertions.assertTrue(this.constructors.any { constructor ->
         constructor.parameterTypes.filter { it != DefaultConstructorMarker::class.java }.size == primary.size
-    }) { constructorErrorMessage }
+    }, constructorErrorMessage)
 }
 
 private fun Class<*>.hasSameVisibilityWith(testClass: TestClass) = this.getVisibility() == testClass.visibility

--- a/core/src/main/kotlin/org/jetbrains/academy/test/system/core/KTypeUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/academy/test/system/core/KTypeUtils.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.academy.test.system.core
 
 import org.jetbrains.academy.test.system.core.models.TestKotlinType
+import org.junit.jupiter.api.Assertions
 import kotlin.reflect.KType
 import kotlin.reflect.jvm.javaType
 
@@ -21,20 +22,28 @@ fun KType.checkType(
         // We have a parametrized type
         if ("<" in this.javaType.toString() && kotlinType?.abbreviation == null) {
             val type = kotlinType?.getTypePrettyString() ?: javaType
-            assert(type.lowercase() in this.javaType.toString().lowercase()) { message }
+            Assertions.assertTrue(type.lowercase() in this.javaType.toString().lowercase(), message)
         } else {
-            assert(this.javaType.getShortName() == javaType.lowercase()) { message }
+            Assertions.assertEquals(this.javaType.getShortName(), javaType.lowercase(), message)
         }
     }
 }
 
 private fun KType.checkNullability(kotlinType: TestKotlinType, errorMessagePrefix: String) {
     val nullablePrefix = if (!kotlinType.isNullable) "" else "not"
-    assert(this.isMarkedNullable == kotlinType.isNullable) { "Error, $errorMessagePrefix must be $nullablePrefix nullable" }
+    Assertions.assertEquals(
+        this.isMarkedNullable,
+        kotlinType.isNullable,
+        "Error, $errorMessagePrefix must be $nullablePrefix nullable"
+    )
 }
 
 private fun KType.checkAbbreviation(abbreviation: String, errorMessagePrefix: String) {
-    assert(this.getAbbreviation() == abbreviation) { "The return type for $errorMessagePrefix must contain $abbreviation" }
+    Assertions.assertEquals(
+        this.getAbbreviation(),
+        abbreviation,
+        "The return type for $errorMessagePrefix must contain $abbreviation"
+    )
 }
 
 private fun KType.getAbbreviation(): String {

--- a/core/src/main/kotlin/org/jetbrains/academy/test/system/core/MethodUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/academy/test/system/core/MethodUtils.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.academy.test.system.core
 
 import org.jetbrains.academy.test.system.core.models.method.TestMethod
+import org.junit.jupiter.api.Assertions
 import java.lang.reflect.Method
 
 fun Method.invokeWithoutArgs(
@@ -24,9 +25,7 @@ fun Method.invokeWithArgs(
 
 private fun List<Method>.filterByCondition(errorMessage: String, condition: (Method) -> Boolean): List<Method> {
     val filteredByCondition = this.filter { condition(it) }
-    if (filteredByCondition.isEmpty()) {
-        assert(false) { errorMessage }
-    }
+    Assertions.assertTrue(filteredByCondition.isNotEmpty(), errorMessage)
     return filteredByCondition
 }
 
@@ -49,6 +48,11 @@ fun Array<Method>.findMethod(method: TestMethod, customErrorMessage: String? = n
         filteredByType.filterByCondition(customErrorMessage ?: "The method ${method.name} should have ${method.arguments.size} arguments") { it.parameterCount == method.arguments.size }
     val args = method.arguments.map { it.javaType.lowercase() }
     val methods = filteredByArgumentsCount.filterByCondition(customErrorMessage ?: "The method ${method.prettyString()} is missed. Check it's arguments properly." ) { m -> m.parameterTypes.map { it.name.getShortName().lowercase() } == args }
-    require(methods.size == 1) { customErrorMessage ?: "The method ${method.name} should have ${method.arguments.size} arguments: $args. The full signature is: ${method.prettyString()}." }
+    Assertions.assertEquals(
+        methods.size,
+        1,
+        customErrorMessage
+            ?: "The method ${method.name} should have ${method.arguments.size} arguments: $args. The full signature is: ${method.prettyString()}."
+    )
     return methods.first()
 }

--- a/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/method/TestMethod.kt
+++ b/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/method/TestMethod.kt
@@ -4,6 +4,7 @@ import org.jetbrains.academy.test.system.core.checkType
 import org.jetbrains.academy.test.system.core.models.TestKotlinType
 import org.jetbrains.academy.test.system.core.models.Visibility
 import org.jetbrains.academy.test.system.core.models.variable.TestVariable
+import org.junit.jupiter.api.Assertions
 import java.lang.reflect.Method
 import kotlin.reflect.jvm.kotlinFunction
 
@@ -40,9 +41,13 @@ data class TestMethod(
     fun checkMethod(method: Method) {
         val kotlinFunction =
             method.kotlinFunction ?: error("Can not find Kotlin method for the method ${this.prettyString()}")
-        assert(kotlinFunction.name == name) { "The function name must be: $name" }
+        Assertions.assertEquals(kotlinFunction.name, name, "The function name must be: $name")
         val visibility = kotlinFunction.visibility?.name?.lowercase()
-        assert(visibility == this.visibility.key) { "The visibility of the method $name must be ${this.visibility.key}" }
+        Assertions.assertEquals(
+            visibility,
+            this.visibility.key,
+            "\"The visibility of the method $name must be ${this.visibility.key}\""
+        )
         kotlinFunction.returnType.checkType(returnType, returnTypeJava ?: returnType.type, "the function $name")
     }
 }

--- a/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/variable/FieldProperties.kt
+++ b/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/variable/FieldProperties.kt
@@ -4,6 +4,7 @@ import org.jetbrains.academy.test.system.core.getShortName
 import org.jetbrains.academy.test.system.core.models.Visibility
 import org.jetbrains.academy.test.system.core.models.asVisibility
 import org.jetbrains.academy.test.system.core.models.getVisibility
+import org.junit.jupiter.api.Assertions
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 import kotlin.reflect.KProperty
@@ -46,17 +47,21 @@ internal data class FieldProperties(
     }
 
     fun checkProperties(variable: TestVariable, toCheckMutability: Boolean) {
-        assert(name == variable.name) { "The field name must be: ${variable.name}" }
+        Assertions.assertEquals(name, variable.name, "The field name must be: ${variable.name}")
         val visibilityErrorMessage = variable.visibility?.let {
             "The visibility of the field ${variable.name} must be ${it.key}"
         } ?: "The filed ${variable.name} should not have any modifiers"
-        assert(visibility?.key?.lowercase() == variable.visibility?.key) { visibilityErrorMessage }
+        Assertions.assertEquals(visibility?.key?.lowercase(), variable.visibility?.key, visibilityErrorMessage)
         if (toCheckMutability) {
             val mutabilityErrorMessage = variable.mutability?.let {
                 "The field ${variable.name} must be ${it.key}"
             } ?: "The filed ${variable.name} should not have val or var key words"
-            assert(mutability.compareWith(variable.mutability)) { mutabilityErrorMessage }
+            Assertions.assertTrue(mutability.compareWith(variable.mutability), mutabilityErrorMessage)
         }
-        assert(javaType == variable.javaType.lowercase()) { "The return type of the field ${variable.name} must be ${variable.javaType.lowercase()}" }
+        Assertions.assertEquals(
+            javaType,
+            variable.javaType.lowercase(),
+            "The return type of the field ${variable.name} must be ${variable.javaType.lowercase()}"
+        )
     }
 }

--- a/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/variable/TestVariable.kt
+++ b/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/variable/TestVariable.kt
@@ -6,6 +6,7 @@ import org.jetbrains.academy.test.system.core.checkType
 import org.jetbrains.academy.test.system.core.models.TestKotlinType
 import org.jetbrains.academy.test.system.core.models.Visibility
 import org.jetbrains.academy.test.system.core.throwInternalLibError
+import org.junit.jupiter.api.Assertions
 import java.io.File
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
@@ -55,13 +56,16 @@ data class TestVariable(
             )
         commonProp.checkProperties(this, toCheckMutability)
         if (isStatic) {
-            assert(Modifier.isStatic(field.modifiers)) { "The field $name must be defined into an object or a companion object." }
+            Assertions.assertTrue(
+                Modifier.isStatic(field.modifiers),
+                "The field $name must be defined into an object or a companion object."
+            )
         }
         if (isConst) {
             val errorMessage = "The field $name must be a const value."
-            assert(Modifier.isFinal(field.modifiers)) { errorMessage }
+            Assertions.assertTrue(Modifier.isFinal(field.modifiers), errorMessage)
             field.kotlinProperty?.isConst?.let {
-                assert(it) { errorMessage }
+                Assertions.assertTrue(it, errorMessage)
             }
         }
         field.kotlinProperty?.returnType?.checkType(
@@ -93,7 +97,7 @@ fun checkListOfVariables(sourceCodeFile: File, variables: List<TestVariable>) {
     if (sourceCodeFile.exists()) {
         val content = sourceCodeFile.readText()
         for (variable in variables) {
-            assert(variable.isVariableExist(content))
+            Assertions.assertTrue(variable.isVariableExist(content))
         }
     } else {
         // TODO: log some errors?

--- a/core/src/test/kotlin/org/jetbrains/academy/test/system/core/DataClassTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/academy/test/system/core/DataClassTests.kt
@@ -5,6 +5,7 @@ import org.jetbrains.academy.test.system.core.models.classes.ConstructorGetter
 import org.jetbrains.academy.test.system.core.models.method.TestMethod
 import org.jetbrains.academy.test.system.core.models.method.TestMethodInvokeData
 import org.jetbrains.academy.test.system.core.testData.dataClass.*
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -46,7 +47,11 @@ class DataClassTests {
             val instance = constructor.newInstance(publicVal, "aliasToString", 5)
             val publicValGetterMethod = clazz.methods.findMethod(publicValGetterMethod)
             val publicValActual = dataClassTestClass.invokeMethodWithoutArgs(clazz, instance, publicValGetterMethod)
-            assert(publicVal == publicValActual.toString()) { "The instance of the class ${dataClassTestClass.name} must have value $publicVal in the publicVal field if it was passed into the constructor" }
+            Assertions.assertEquals(
+                publicVal,
+                publicValActual.toString(),
+                "The instance of the class ${dataClassTestClass.name} must have value $publicVal in the publicVal field if it was passed into the constructor"
+            )
         }
     }
 
@@ -69,7 +74,11 @@ class DataClassTests {
             invokeData = invokeData,
             isPrivate = sumMethod.visibility == Visibility.PRIVATE
         ).toString()
-        assert(expected.toString() == actualSum) { "For a = $a and b = $b the method ${sumMethod.name} must return $expected." }
+        Assertions.assertEquals(
+            expected.toString(),
+            actualSum,
+            "For a = $a and b = $b the method ${sumMethod.name} must return $expected."
+        )
     }
 
     private fun TestMethod.getInvokeData() = TestMethodInvokeData(
@@ -85,7 +94,7 @@ class DataClassTests {
             invokeData = invokeData,
             isPrivate = constMethod.visibility == Visibility.PRIVATE
         ).toString()
-        assert("5" == actualConst) { "The method ${constMethod.name} must return 5." }
+        Assertions.assertEquals("5", actualConst, "The method ${constMethod.name} must return 5.")
     }
 
     @Test

--- a/ij/src/main/kotlin/org/jetbrains/academy/test/system/ij/analyzer/IjCodeAnalyzerUtil.kt
+++ b/ij/src/main/kotlin/org/jetbrains/academy/test/system/ij/analyzer/IjCodeAnalyzerUtil.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.util.parentsOfType
 import org.jetbrains.academy.test.system.ij.formatting.formatting
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.*
+import org.junit.jupiter.api.Assertions
 
 /** Extracts [kotlin elements][KtElement] of given type from kotlin related files in project. */
 /** Extracts elements of given type from [PsiElement] subtree. */
@@ -27,7 +28,7 @@ private fun KtProperty.getConstValue(): String? {
     if (possibleValue.isEmpty()) {
         return null
     }
-    require(possibleValue.size == 1) { "Parser error! A const variable must have only one value" }
+    Assertions.assertEquals(possibleValue.size, 1, "Parser error! A const variable must have only one value")
     return possibleValue.first().text.trimIndent()
 }
 

--- a/ij/src/main/kotlin/org/jetbrains/academy/test/system/ij/formatting/FormattingUtil.kt
+++ b/ij/src/main/kotlin/org/jetbrains/academy/test/system/ij/formatting/FormattingUtil.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.codeStyle.CodeStyleManager
 import org.jetbrains.academy.test.system.inspections.applyInspections
 import org.jetbrains.kotlin.idea.inspections.KotlinUnusedImportInspection
+import org.junit.jupiter.api.Assertions
 
 // TODO: make it possible to check different aspects of formatting
 fun PsiFile.checkIfFormattingRulesWereApplied() {
@@ -17,7 +18,11 @@ fun PsiFile.checkIfFormattingRulesWereApplied() {
         codeStyleManager.reformat(this)
     }
     val formattedCode = ApplicationManager.getApplication().runReadAction<String> { text }
-    assert(originalCode.trimIndent() == formattedCode.trimIndent()) { "The code after formatting should be:${System.lineSeparator()}$formattedCode${System.lineSeparator()}Please, apply code formatting refactoring to the code." }
+    Assertions.assertEquals(
+        originalCode.trimIndent(),
+        formattedCode.trimIndent(),
+        "The code after formatting should be:${System.lineSeparator()}$formattedCode${System.lineSeparator()}Please, apply code formatting refactoring to the code."
+    )
 }
 
 fun PsiFile.formatting(): String? {
@@ -29,7 +34,8 @@ fun PsiFile.formatting(): String? {
 }
 
 fun PsiFile.checkIfOptimizeImportsWereApplied() {
-    assert(applyInspections(listOf(KotlinUnusedImportInspection())).isEmpty()) {
+    Assertions.assertTrue(
+        applyInspections(listOf(KotlinUnusedImportInspection())).isEmpty(),
         "Please, apply \"Optimize import\" option when formatting code."
-    }
+    )
 }

--- a/ij/src/test/kotlin/org/jetbrains/academy/test/system/ij/formatting/BaseIjTestClassTests.kt
+++ b/ij/src/test/kotlin/org/jetbrains/academy/test/system/ij/formatting/BaseIjTestClassTests.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.academy.test.system.ij.formatting
 
 import org.jetbrains.academy.test.system.test.BaseIjTestClass
+import org.junit.jupiter.api.Assertions
 
 class BaseIjTestClassTests : BaseIjTestClass() {
 
@@ -32,9 +33,11 @@ class BaseIjTestClassTests : BaseIjTestClass() {
             println(actions)
         """.trimIndent()
         val methodName = "method1"
-        assert(listOf(methodName).equals(findMethodsWithContent(content))) {
+        Assertions.assertEquals(
+            listOf(methodName),
+            findMethodsWithContent(content),
             "The name of a method with this content \n $content \n must be $methodName"
-        }
+        )
     }
 
     fun testFindMethodsWithSingleLineContent() {
@@ -46,9 +49,11 @@ class BaseIjTestClassTests : BaseIjTestClass() {
         myFixture.configureByText("Task.kt", example)
         val content = """"Some actions"""".trimIndent()
         val methodName = "method"
-        assert(listOf(methodName).equals(findMethodsWithContent(content))) {
+        Assertions.assertEquals(
+            listOf(methodName),
+            findMethodsWithContent(content),
             "The name of a method with this content \n $content \n must be $methodName"
-        }
+        )
     }
 
     fun testFindMethodsWithContentWithBrokenFormatting() {
@@ -73,9 +78,11 @@ class BaseIjTestClassTests : BaseIjTestClass() {
             println(actions)
         """.trimIndent()
         val methodName = "method1"
-        assert(listOf(methodName).equals(findMethodsWithContent(content))) {
+        Assertions.assertEquals(
+            listOf(methodName),
+            findMethodsWithContent(content),
             "The name of a method with this content \n $content \n must be $methodName"
-        }
+        )
     }
 
     fun testFindMethodsWithContentWithNestedBodies() {
@@ -92,9 +99,11 @@ class BaseIjTestClassTests : BaseIjTestClass() {
         myFixture.configureByText("Task.kt", example)
         val content = "return y * y"
         val methodName = "innerFunction"
-        assert(listOf(methodName).equals(findMethodsWithContent(content))) {
+        Assertions.assertEquals(
+            listOf(methodName),
+            findMethodsWithContent(content),
             "The name of a method with this content \n $content \n must be $methodName"
-        }
+        )
     }
 
     fun testHasConstantWithGivenValue() {
@@ -107,13 +116,13 @@ class BaseIjTestClassTests : BaseIjTestClass() {
         """.trimIndent()
         myFixture.configureByText("Task.kt", example)
         var value = "\"some text\""
-        assert(hasConstantWithGivenValue(value)) { "There must exist a constant with value $value" }
+        Assertions.assertTrue(hasConstantWithGivenValue(value), "There must exist a constant with value $value")
         value = "2"
-        assert(hasConstantWithGivenValue(value)) { "There must exist a constant with value $value" }
+        Assertions.assertTrue(hasConstantWithGivenValue(value), "There must exist a constant with value $value")
         value = "50"
-        assert(hasConstantWithGivenValue(value)) { "There must exist a constant with value $value" }
-        assertFalse(hasConstantWithGivenValue("0.5"))
-        assertFalse(hasConstantWithGivenValue("500"))
+        Assertions.assertTrue(hasConstantWithGivenValue(value), "There must exist a constant with value $value")
+        Assertions.assertFalse(hasConstantWithGivenValue("0.5"))
+        Assertions.assertFalse(hasConstantWithGivenValue("500"))
     }
 
     fun testHasConstantWithGivenValueWithBrokenFormatting() {
@@ -124,10 +133,10 @@ class BaseIjTestClassTests : BaseIjTestClass() {
         """.trimIndent()
         myFixture.configureByText("Task.kt", example)
         var value = "\"some text\""
-        assert(hasConstantWithGivenValue(value)) { "There must exist a constant with value $value" }
+        Assertions.assertTrue(hasConstantWithGivenValue(value), "There must exist a constant with value $value")
         value = "2"
-        assert(hasConstantWithGivenValue(value)) { "There must exist a constant with value $value" }
-        assertFalse(hasConstantWithGivenValue("0.5"))
+        Assertions.assertTrue(hasConstantWithGivenValue(value), "There must exist a constant with value $value")
+        Assertions.assertFalse(hasConstantWithGivenValue("0.5"))
     }
 
     fun testFindMethodUsages() {
@@ -165,24 +174,28 @@ class BaseIjTestClassTests : BaseIjTestClass() {
         myFixture.configureByText("Task.kt", example)
         var methodName = "method(\"Content\")"
         var methodsList = listOf("innerFunction", "method2")
-        assert(methodsList.equals(findMethodUsages(methodName))) {
+        Assertions.assertEquals(
+            methodsList,
+            findMethodUsages(methodName),
             "Method $methodName should be called in methods: $methodsList"
-        }
+        )
         methodName = "method(\"y is greater than 5\")"
         methodsList = listOf("method1")
-        assert(methodsList.equals(findMethodUsages(methodName))) {
+        Assertions.assertEquals(
+            methodsList,
+            findMethodUsages(methodName),
             "Method $methodName should be called in methods: $methodsList"
-        }
+        )
         methodName = "method(\"y is less than 5\")"
         methodsList = listOf("method1")
-        assert(methodsList.equals(findMethodUsages(methodName))) {
+        Assertions.assertEquals(
+            methodsList,
+            findMethodUsages(methodName),
             "Method $methodName should be called in methods: $methodsList"
-        }
+        )
         methodName = "method(content)"
         methodsList = listOf()
-        assert(methodsList.equals(findMethodUsages(methodName))) {
-            "Method $methodName should not be called"
-        }
+        Assertions.assertEquals(methodsList, findMethodUsages(methodName), "Method $methodName should not be called")
     }
 
     fun testHasProperty() {
@@ -197,13 +210,13 @@ class BaseIjTestClassTests : BaseIjTestClass() {
         """.trimIndent()
         myFixture.configureByText("Task.kt", example)
         var value = "CONSTANT"
-        assert(hasProperty(value)) { "There must exist a property with name $value" }
+        Assertions.assertTrue(hasProperty(value), "There must exist a property with name $value")
         value = "value"
-        assert(hasProperty(value)) { "There must exist a property with name $value" }
+        Assertions.assertTrue(hasProperty(value), "There must exist a property with name $value")
         value = "number"
-        assert(hasProperty(value)) { "There must exist a property with name $value" }
-        assertFalse(hasProperty("method"))
-        assertFalse(hasProperty("Content"))
+        Assertions.assertTrue(hasProperty(value), "There must exist a property with name $value")
+        Assertions.assertFalse(hasProperty("method"))
+        Assertions.assertFalse(hasProperty("Content"))
     }
 
     fun testHasMethod() {
@@ -229,13 +242,13 @@ class BaseIjTestClassTests : BaseIjTestClass() {
         """.trimIndent()
         myFixture.configureByText("Task.kt", example)
         var value = "method"
-        assert(hasMethod(value)) { "There must exist a method with name $value" }
+        Assertions.assertTrue(hasMethod(value), "There must exist a method with name $value")
         value = "notMethod"
-        assert(hasMethod(value)) { "There must exist a method with name $value" }
+        Assertions.assertTrue(hasMethod(value), "There must exist a method with name $value")
         value = "value"
-        assert(hasMethod(value)) { "There must exist a method with name $value" }
-        assertFalse(hasMethod("CONSTANT"))
-        assertFalse(hasMethod("Content"))
+        Assertions.assertTrue(hasMethod(value), "There must exist a method with name $value")
+        Assertions.assertFalse(hasMethod("CONSTANT"))
+        Assertions.assertFalse(hasMethod("Content"))
     }
 
     fun testHasExpressionWithParent() {
@@ -254,26 +267,30 @@ class BaseIjTestClassTests : BaseIjTestClass() {
         myFixture.configureByText("Task.kt", example)
         var expression: String = "productPrice.sum()"
         var parent: String? = "productPrice.sum() / productPrice.count()"
-        assert(hasExpressionWithParent(expression, parent)) {
+        Assertions.assertTrue(
+            hasExpressionWithParent(expression, parent),
             "There must exist an expression $expression with parent $parent"
-        }
+        )
         expression = "File(\"Exception.txt\")"
         parent = "File(\"Exception.txt\")"
-        assert(hasExpressionWithParent(expression, parent)) {
+        Assertions.assertTrue(
+            hasExpressionWithParent(expression, parent),
             "There must exist an expression $expression with parent $parent"
-        }
+        )
         expression = "PrintWriter(File(\"Exception.txt\"), Charsets.UTF_8).use { it.print(error.toString()) }"
         parent = "calculateAveragePrice"
-        assert(hasExpressionWithParent(expression, parent, true)) {
+        Assertions.assertTrue(
+            hasExpressionWithParent(expression, parent, true),
             "There must exist an expression $expression with parent $parent"
-        }
+        )
         expression = "Int.MAX_VALUE"
         parent = "val CONSTANT = Int.MAX_VALUE"
-        assertFalse(hasExpressionWithParent(expression, parent))
+        Assertions.assertFalse(hasExpressionWithParent(expression, parent))
         expression = "Int.MAX_VALUE"
         parent = null
-        assert(hasExpressionWithParent(expression, parent, true)) {
+        Assertions.assertTrue(
+            hasExpressionWithParent(expression, parent, true),
             "There must exist an expression $expression with parent $parent"
-        }
+        )
     }
 }


### PR DESCRIPTION
**Changes**:
- Replaced all `assert` and `require` methods with their analogues from `org.junit.jupiter.api.Assertions`
- Moved JUnit dependencies from the `core` module to the main `build.gradle.kts` file
- Bumped the version from `2.0.7` to `2.1.0`