### PR TITLE
Added fixes for java-psi module

### DIFF
--- a/ij/java-psi/src/main/kotlin/org/jetbrains/academy/test/system/java/ij/analyzer/PsiFileAnalyzerUtil.kt
+++ b/ij/java-psi/src/main/kotlin/org/jetbrains/academy/test/system/java/ij/analyzer/PsiFileAnalyzerUtil.kt
@@ -2,6 +2,7 @@ package org.jetbrains.academy.test.system.java.ij.analyzer
 
 import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiField
@@ -48,7 +49,7 @@ private fun formattingContent(content: String, project: Project): String {
  * @return A list of method names whose bodies match the provided content.
  */
 fun PsiFile.findMethodsWithContent(content: String): List<String> =
-    ApplicationManager.getApplication().runReadAction<List<String>> {
+    WriteCommandAction.runWriteCommandAction<List<String>>(project) {
         formatting()
         val formattingContent = formattingContent(content, project)
 

--- a/ij/java-psi/src/main/kotlin/org/jetbrains/academy/test/system/java/test/BaseIjTestClass.kt
+++ b/ij/java-psi/src/main/kotlin/org/jetbrains/academy/test/system/java/test/BaseIjTestClass.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiCallExpression
+import com.intellij.psi.PsiLocalVariable
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.jetbrains.academy.test.system.ij.analyzer.findMethodUsages
 import org.jetbrains.academy.test.system.ij.analyzer.hasElementOfTypeWithName
@@ -29,8 +30,11 @@ open class BaseIjTestClass : BasePlatformTestCase() {
     fun findMethodUsages(content: String): List<String> =
         myFixture.file.findMethodUsages(content, PsiCallExpression::class.java, PsiMethod::class.java)
 
-    fun hasProperty(propertyName: String): Boolean =
-        myFixture.file.hasElementOfTypeWithName(PsiField::class.java, propertyName)
+    fun hasField(fieldName: String): Boolean =
+        myFixture.file.hasElementOfTypeWithName(PsiField::class.java, fieldName)
+
+    fun hasLocalVariable(localVariableName: String): Boolean =
+        myFixture.file.hasElementOfTypeWithName(PsiLocalVariable::class.java, localVariableName)
 
     fun hasMethod(methodName: String): Boolean =
         myFixture.file.hasElementOfTypeWithName(PsiMethod::class.java, methodName)

--- a/ij/java-psi/src/test/kotlin/org/jetbrains/academy/test/system/java/ij/BaseIjTestClassTests.kt
+++ b/ij/java-psi/src/test/kotlin/org/jetbrains/academy/test/system/java/ij/BaseIjTestClassTests.kt
@@ -193,7 +193,7 @@ class BaseIjTestClassTests : BaseIjTestClass() {
         }
     }
 
-    fun testHasProperty() {
+    fun testHasField() {
         val example = """
             public class ExampleClass {
                 private static final String CONSTANT = "some text";
@@ -201,19 +201,41 @@ class BaseIjTestClassTests : BaseIjTestClass() {
                 private int number = 2;
 
                 public void method() {
+                    double waveLength = 0.5e-6;
                     System.out.println("Content");
                 }
             }
         """.trimIndent()
         myFixture.configureByText("Task.java", example)
         var value = "CONSTANT"
-        assert(hasProperty(value)) { "There must exist a property with name $value" }
+        assert(hasField(value)) { "There must exist a property with name $value" }
         value = "value"
-        assert(hasProperty(value)) { "There must exist a property with name $value" }
+        assert(hasField(value)) { "There must exist a property with name $value" }
         value = "number"
-        assert(hasProperty(value)) { "There must exist a property with name $value" }
-        assertFalse(hasProperty("method"))
-        assertFalse(hasProperty("Content"))
+        assert(hasField(value)) { "There must exist a property with name $value" }
+        assertFalse(hasField("method"))
+        assertFalse(hasField("Content"))
+    }
+
+    fun testHasLocalVariable() {
+        val example = """
+            public class ExampleClass {
+                private static final String CONSTANT = "some text";
+
+                public void method() {
+                    double value = 0.5;
+                    int number = 2;
+                    System.out.println("Content");
+                }
+            }
+        """.trimIndent()
+        myFixture.configureByText("Task.java", example)
+        var value = "value"
+        assert(hasLocalVariable(value)) { "There must exist a local variable with name $value" }
+        value = "number"
+        assert(hasLocalVariable(value)) { "There must exist a local variable with name $value" }
+        assertFalse(hasLocalVariable("CONSTANT"))
+        assertFalse(hasLocalVariable("Content"))
     }
 
     fun testHasMethod() {


### PR DESCRIPTION
1. Divided the `hasProperty` function into two - `hasField` and `hasLocalVariable`, because in Kotlin a field and a local variable are properties, but not in Java 
2. Fixed error in `findMethodsWithContent` function