### PR TITLE
Added tests for Java and fixes to support Java

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.jetbrains.academy.test.system"
-version = "2.1.1"
+version = "2.1.2"
 
 allprojects {
     apply {

--- a/core/src/main/kotlin/org/jetbrains/academy/test/system/core/MethodUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/academy/test/system/core/MethodUtils.kt
@@ -39,9 +39,9 @@ fun Array<Method>.findMethod(method: TestMethod, customErrorMessage: String? = n
                 it.name == method.name
             }
         }
-    val returnTypeJava = (method.returnTypeJava?.let { listOf(it) } ?: listOfNotNull(method.returnType.type, *method.returnType.possibleBounds.toTypedArray())).map { it.lowercase() }
+    val returnTypeJava = (listOf(method.returnTypeJava)).map { it.lowercase() }
     val filteredByType =
-        filteredByName.filterByCondition(customErrorMessage ?: "The method ${method.name} should have the return type ${method.returnType.getTypePrettyString()}") {
+        filteredByName.filterByCondition(customErrorMessage ?: "The method ${method.name} should have the return type ${method.returnType?.getTypePrettyString()}") {
             it.returnType.name.getShortName().lowercase() in returnTypeJava
         }
     val filteredByArgumentsCount =

--- a/core/src/main/kotlin/org/jetbrains/academy/test/system/core/MethodUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/academy/test/system/core/MethodUtils.kt
@@ -39,9 +39,9 @@ fun Array<Method>.findMethod(method: TestMethod, customErrorMessage: String? = n
                 it.name == method.name
             }
         }
-    val returnTypeJava = (listOf(method.returnTypeJava)).map { it.lowercase() }
+    val returnTypeJava = (method.returnTypeJava?.let { listOf(it) } ?: listOfNotNull(method.returnType.type, *method.returnType.possibleBounds.toTypedArray())).map { it.lowercase() }
     val filteredByType =
-        filteredByName.filterByCondition(customErrorMessage ?: "The method ${method.name} should have the return type ${method.returnType?.getTypePrettyString()}") {
+        filteredByName.filterByCondition(customErrorMessage ?: "The method ${method.name} should have the return type ${method.returnType.getTypePrettyString()}") {
             it.returnType.name.getShortName().lowercase() in returnTypeJava
         }
     val filteredByArgumentsCount =

--- a/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/method/TestMethod.kt
+++ b/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/method/TestMethod.kt
@@ -20,9 +20,9 @@ import kotlin.reflect.jvm.kotlinFunction
  */
 data class TestMethod(
     val name: String,
-    val returnTypeJava: String,
-    val returnType: TestKotlinType? = null,
+    val returnType: TestKotlinType,
     val arguments: List<TestVariable> = emptyList(),
+    val returnTypeJava: String? = null,
     val visibility: Visibility = Visibility.PUBLIC,
     val hasGeneratedPartInName: Boolean = false,
 ) {
@@ -33,14 +33,12 @@ data class TestMethod(
         visibility: Visibility
     ) : this(
         name = name,
-        returnTypeJava = returnTypeJava,
-        returnType = null,
+        returnType = TestKotlinType(returnTypeJava),
         arguments = arguments,
+        returnTypeJava = returnTypeJava,
         visibility = visibility,
         hasGeneratedPartInName = false
     )
-
-    private fun getTypePrettyString() = returnType?.getTypePrettyString() ?: returnTypeJava
 
     fun prettyString(withToDo: Boolean = true): String {
         val args = arguments.joinToString(", ") { it.paramPrettyString() }
@@ -49,7 +47,7 @@ data class TestMethod(
         } else {
             "// Some code"
         }
-        return "${visibility.key} fun $name($args): ${getTypePrettyString()} = $body"
+        return "${visibility.key} fun $name($args): ${returnType.getTypePrettyString()} = $body"
     }
 
     private fun TestVariable.paramPrettyString() = "$name: $javaType"
@@ -64,6 +62,6 @@ data class TestMethod(
             this.visibility.key,
             "\"The visibility of the method $name must be ${this.visibility.key}\""
         )
-        kotlinFunction.returnType.checkType(returnType, returnTypeJava, "the function $name")
+        kotlinFunction.returnType.checkType(returnType, returnTypeJava ?: returnType.type, "the function $name")
     }
 }

--- a/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/method/TestMethod.kt
+++ b/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/method/TestMethod.kt
@@ -20,12 +20,28 @@ import kotlin.reflect.jvm.kotlinFunction
  */
 data class TestMethod(
     val name: String,
-    val returnType: TestKotlinType,
+    val returnTypeJava: String,
+    val returnType: TestKotlinType? = null,
     val arguments: List<TestVariable> = emptyList(),
-    val returnTypeJava: String? = null,
     val visibility: Visibility = Visibility.PUBLIC,
     val hasGeneratedPartInName: Boolean = false,
 ) {
+    constructor(
+        name: String,
+        returnTypeJava: String,
+        arguments: List<TestVariable>,
+        visibility: Visibility
+    ) : this(
+        name = name,
+        returnTypeJava = returnTypeJava,
+        returnType = null,
+        arguments = arguments,
+        visibility = visibility,
+        hasGeneratedPartInName = false
+    )
+
+    private fun getTypePrettyString() = returnType?.getTypePrettyString() ?: returnTypeJava
+
     fun prettyString(withToDo: Boolean = true): String {
         val args = arguments.joinToString(", ") { it.paramPrettyString() }
         val body = if (withToDo) {
@@ -33,7 +49,7 @@ data class TestMethod(
         } else {
             "// Some code"
         }
-        return "${visibility.key} fun $name($args): ${returnType.getTypePrettyString()} = $body"
+        return "${visibility.key} fun $name($args): ${getTypePrettyString()} = $body"
     }
 
     private fun TestVariable.paramPrettyString() = "$name: $javaType"
@@ -48,6 +64,6 @@ data class TestMethod(
             this.visibility.key,
             "\"The visibility of the method $name must be ${this.visibility.key}\""
         )
-        kotlinFunction.returnType.checkType(returnType, returnTypeJava ?: returnType.type, "the function $name")
+        kotlinFunction.returnType.checkType(returnType, returnTypeJava, "the function $name")
     }
 }

--- a/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/variable/TestVariable.kt
+++ b/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/variable/TestVariable.kt
@@ -39,6 +39,29 @@ data class TestVariable(
     val isConst: Boolean = false,
     // TODO: add nullability?
 ) {
+    constructor(
+        name: String,
+        javaType: String,
+        value: String?,
+        visibility: Visibility?,
+        isFinal: Boolean,
+        isInPrimaryConstructor: Boolean,
+        isStatic: Boolean,
+        isConst: Boolean
+    ) : this(
+        name = name,
+        javaType = javaType,
+        value = value,
+        kotlinType = null,
+        visibility = visibility,
+        mutability = if (isFinal) VariableMutability.VAL else VariableMutability.VAR,
+        isInPrimaryConstructor = isInPrimaryConstructor,
+        isStatic = isStatic,
+        isConst = isConst
+    )
+
+    constructor(name: String, javaType: String) : this(name, javaType, null, null, null, null, false, false, false)
+
     private fun getTypePrettyString() = kotlinType?.getTypePrettyString() ?: javaType
 
     fun prettyString(): String {
@@ -69,10 +92,7 @@ data class TestVariable(
             }
         }
         field.kotlinProperty?.returnType?.checkType(
-            kotlinType,
-            javaType,
-            "the field $name",
-            false
+            kotlinType, javaType, "the field $name", false
         )
     }
 }
@@ -86,8 +106,7 @@ fun TestVariable.isVariableExist(fileContent: String): Boolean {
     val defWithType = variableDefTemplateWithType()
     if (!(baseDef in fileContent || defWithType in fileContent)) {
         error(
-            "The code should contains a definition of the ${this.name} variable! " +
-                    "Please, add <$baseDef> or <$defWithType> code in your solution."
+            "The code should contains a definition of the ${this.name} variable! " + "Please, add <$baseDef> or <$defWithType> code in your solution."
         )
     }
     return true

--- a/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/variable/TestVariable.kt
+++ b/core/src/main/kotlin/org/jetbrains/academy/test/system/core/models/variable/TestVariable.kt
@@ -46,8 +46,7 @@ data class TestVariable(
         visibility: Visibility?,
         isFinal: Boolean,
         isInPrimaryConstructor: Boolean,
-        isStatic: Boolean,
-        isConst: Boolean
+        isStatic: Boolean
     ) : this(
         name = name,
         javaType = javaType,
@@ -57,7 +56,7 @@ data class TestVariable(
         mutability = if (isFinal) VariableMutability.VAL else VariableMutability.VAR,
         isInPrimaryConstructor = isInPrimaryConstructor,
         isStatic = isStatic,
-        isConst = isConst
+        isConst = isStatic && isFinal
     )
 
     constructor(name: String, javaType: String) : this(name, javaType, null, null, null, null, false, false, false)

--- a/core/src/test/java/org/jetbrains/academy/test/system/core/TestJavaClass.java
+++ b/core/src/test/java/org/jetbrains/academy/test/system/core/TestJavaClass.java
@@ -1,0 +1,154 @@
+package org.jetbrains.academy.test.system.core;
+
+import org.jetbrains.academy.test.system.core.models.Visibility;
+import org.jetbrains.academy.test.system.core.models.classes.ClassType;
+import org.jetbrains.academy.test.system.core.models.classes.TestClass;
+import org.jetbrains.academy.test.system.core.models.method.TestMethod;
+import org.jetbrains.academy.test.system.core.models.variable.TestVariable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+public class TestJavaClass {
+    private static TestClass javaClassTestClass;
+
+    @BeforeAll
+    static void beforeAll() {
+        javaClassTestClass = new TestClass(
+                "JavaClass",
+                "org.jetbrains.academy.test.system.core.testData.java",
+                Visibility.PUBLIC,
+                ClassType.CLASS,
+                List.of(
+                        new TestVariable(
+                                "PUBLIC_CONSTANT",
+                                "int",
+                                "1",
+                                Visibility.PUBLIC,
+                                true,
+                                false,
+                                false,
+                                true
+                        ),
+                        new TestVariable(
+                                "PRIVATE_CONSTANT",
+                                "int",
+                                "2",
+                                Visibility.PRIVATE,
+                                true,
+                                false,
+                                false,
+                                true
+                        ),
+                        new TestVariable(
+                                "publicStaticVar",
+                                "int",
+                                "3",
+                                Visibility.PUBLIC,
+                                false,
+                                false,
+                                true,
+                                false
+                        ),
+                        new TestVariable(
+                                "privateStaticVar",
+                                "int",
+                                "4",
+                                Visibility.PRIVATE,
+                                false,
+                                false,
+                                true,
+                                false
+                        ),
+                        new TestVariable(
+                                "publicVar",
+                                "String",
+                                "publicVar",
+                                Visibility.PUBLIC,
+                                false,
+                                false,
+                                false,
+                                false
+                        ),
+                        new TestVariable(
+                                "privateVar",
+                                "String",
+                                "privateVar",
+                                Visibility.PRIVATE,
+                                false,
+                                false,
+                                false,
+                                false
+                        ),
+                        new TestVariable(
+                                "customClass",
+                                "CustomJavaClass",
+                                null,
+                                Visibility.PUBLIC,
+                                false,
+                                false,
+                                false,
+                                false
+                        ),
+                        new TestVariable(
+                                "primaryConstructorVar",
+                                "String",
+                                null,
+                                Visibility.PUBLIC,
+                                false,
+                                true,
+                                false,
+                                false
+                        )
+                ),
+                List.of(
+                        new TestMethod(
+                                "publicMethod",
+                                "void",
+                                emptyList(),
+                                Visibility.PUBLIC
+                        ),
+                        new TestMethod(
+                                "privateMethod",
+                                "void",
+                                emptyList(),
+                                Visibility.PRIVATE
+                        ),
+                        new TestMethod(
+                                "calculateSum",
+                                "double",
+                                List.of(
+                                        new TestVariable("a", "double"),
+                                        new TestVariable("b", "double")
+                                ),
+                                Visibility.PUBLIC
+                        ),
+                        new TestMethod(
+                                "getString",
+                                "String",
+                                List.of(new TestVariable("string", "String")),
+                                Visibility.PRIVATE
+                        ),
+                        new TestMethod(
+                                "processList",
+                                "List",
+                                List.of(new TestVariable("list", "List")),
+                                Visibility.PUBLIC
+                        )
+                ),
+                false,
+                emptyList(),
+                emptyList()
+        );
+    }
+
+    @Test
+    public void javaClassTest() {
+        Class<?> clazz = javaClassTestClass.checkBaseDefinition();
+        javaClassTestClass.checkFieldsDefinition(clazz, true);
+        javaClassTestClass.checkDeclaredMethods(clazz);
+    }
+}

--- a/core/src/test/java/org/jetbrains/academy/test/system/core/TestJavaClass.java
+++ b/core/src/test/java/org/jetbrains/academy/test/system/core/TestJavaClass.java
@@ -30,7 +30,6 @@ public class TestJavaClass {
                                 Visibility.PUBLIC,
                                 true,
                                 false,
-                                false,
                                 true
                         ),
                         new TestVariable(
@@ -39,7 +38,6 @@ public class TestJavaClass {
                                 "2",
                                 Visibility.PRIVATE,
                                 true,
-                                false,
                                 false,
                                 true
                         ),
@@ -50,8 +48,7 @@ public class TestJavaClass {
                                 Visibility.PUBLIC,
                                 false,
                                 false,
-                                true,
-                                false
+                                true
                         ),
                         new TestVariable(
                                 "privateStaticVar",
@@ -60,15 +57,13 @@ public class TestJavaClass {
                                 Visibility.PRIVATE,
                                 false,
                                 false,
-                                true,
-                                false
+                                true
                         ),
                         new TestVariable(
                                 "publicVar",
                                 "String",
                                 "publicVar",
                                 Visibility.PUBLIC,
-                                false,
                                 false,
                                 false,
                                 false
@@ -78,7 +73,6 @@ public class TestJavaClass {
                                 "String",
                                 "privateVar",
                                 Visibility.PRIVATE,
-                                false,
                                 false,
                                 false,
                                 false
@@ -90,7 +84,6 @@ public class TestJavaClass {
                                 Visibility.PUBLIC,
                                 false,
                                 false,
-                                false,
                                 false
                         ),
                         new TestVariable(
@@ -100,7 +93,6 @@ public class TestJavaClass {
                                 Visibility.PUBLIC,
                                 false,
                                 true,
-                                false,
                                 false
                         )
                 ),

--- a/core/src/test/java/org/jetbrains/academy/test/system/core/testData/java/CustomJavaClass.java
+++ b/core/src/test/java/org/jetbrains/academy/test/system/core/testData/java/CustomJavaClass.java
@@ -1,0 +1,4 @@
+package org.jetbrains.academy.test.system.core.testData.java;
+
+public class CustomJavaClass {
+}

--- a/core/src/test/java/org/jetbrains/academy/test/system/core/testData/java/JavaClass.java
+++ b/core/src/test/java/org/jetbrains/academy/test/system/core/testData/java/JavaClass.java
@@ -1,0 +1,46 @@
+package org.jetbrains.academy.test.system.core.testData.java;
+
+import java.util.List;
+
+public class JavaClass {
+
+    public static final int PUBLIC_CONSTANT = 1;
+    private static final int PRIVATE_CONSTANT = 2;
+
+    public static int publicStaticVar = 3;
+    private static int privateStaticVar = 4;
+
+    public String publicVar = "publicVar";
+    private String privateVar = "privateVar";
+
+    public CustomJavaClass customClass = null;
+
+    public String primaryConstructorVar;
+
+    public JavaClass(String primaryVar) {
+        this.primaryConstructorVar = primaryVar;
+    }
+
+    public void publicMethod() {
+        System.out.println("Public instance method called!");
+    }
+
+    private void privateMethod() {
+        System.out.println("Private instance method called!");
+    }
+
+    public double calculateSum(double a, double b) {
+        return a + b;
+    }
+
+    private String getString(String string) {
+        return string;
+    }
+
+    public List<String> processList(List<String> list) {
+        for (String item : list) {
+            System.out.println("Processing item: " + item);
+        }
+        return List.of("item1", "item2", "item3");
+    }
+}

--- a/core/src/test/kotlin/org/jetbrains/academy/test/system/core/JavaClassTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/academy/test/system/core/JavaClassTests.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.academy.test.system.core
+
+import org.jetbrains.academy.test.system.core.testData.java.javaClassTestClass
+import org.junit.jupiter.api.Test
+
+class JavaClassTests {
+
+    @Test
+    fun javaClassTest() {
+        val clazz = javaClassTestClass.checkBaseDefinition()
+        javaClassTestClass.checkFieldsDefinition(clazz)
+        javaClassTestClass.checkDeclaredMethods(clazz)
+    }
+}

--- a/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/java/TestJavaClass.kt
+++ b/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/java/TestJavaClass.kt
@@ -1,0 +1,129 @@
+package org.jetbrains.academy.test.system.core.testData.java
+
+import org.jetbrains.academy.test.system.core.models.Visibility
+import org.jetbrains.academy.test.system.core.models.classes.TestClass
+import org.jetbrains.academy.test.system.core.models.method.TestMethod
+import org.jetbrains.academy.test.system.core.models.variable.TestVariable
+import org.jetbrains.academy.test.system.core.models.variable.VariableMutability
+
+val javaClassTestClass = TestClass(
+    "JavaClass",
+    "org.jetbrains.academy.test.system.core.testData.java",
+    declaredFields = listOf(
+        TestVariable(
+            name = "PUBLIC_CONSTANT",
+            javaType = "int",
+            value = "1",
+            visibility = Visibility.PUBLIC,
+            mutability = VariableMutability.VAL,
+            isInPrimaryConstructor = false,
+            isConst = true
+        ),
+        TestVariable(
+            name = "PRIVATE_CONSTANT",
+            javaType = "int",
+            value = "2",
+            visibility = Visibility.PRIVATE,
+            mutability = VariableMutability.VAL,
+            isInPrimaryConstructor = false,
+            isConst = true
+        ),
+        TestVariable(
+            name = "publicStaticVar",
+            javaType = "int",
+            value = "3",
+            visibility = Visibility.PUBLIC,
+            mutability = VariableMutability.VAR,
+            isInPrimaryConstructor = false,
+            isStatic = true
+        ),
+        TestVariable(
+            name = "privateStaticVar",
+            javaType = "int",
+            value = "4",
+            visibility = Visibility.PRIVATE,
+            mutability = VariableMutability.VAR,
+            isInPrimaryConstructor = false,
+            isStatic = true
+        ),
+        TestVariable(
+            name = "publicVar",
+            javaType = "String",
+            value = "publicVar",
+            visibility = Visibility.PUBLIC,
+            mutability = VariableMutability.VAR,
+            isInPrimaryConstructor = false,
+        ),
+        TestVariable(
+            name = "privateVar",
+            javaType = "String",
+            value = "privateVar",
+            visibility = Visibility.PRIVATE,
+            mutability = VariableMutability.VAR,
+            isInPrimaryConstructor = false,
+        ),
+        TestVariable(
+            name = "customClass",
+            javaType = "CustomJavaClass",
+            visibility = Visibility.PUBLIC,
+            mutability = VariableMutability.VAR,
+            isInPrimaryConstructor = false,
+        ),
+        TestVariable(
+            name = "primaryConstructorVar",
+            javaType = "String",
+            visibility = Visibility.PUBLIC,
+            mutability = VariableMutability.VAR,
+            isInPrimaryConstructor = true,
+        ),
+    ),
+    customMethods = listOf(
+        TestMethod(
+            name = "publicMethod",
+            returnTypeJava = "void",
+            visibility = Visibility.PUBLIC
+        ),
+        TestMethod(
+            name = "privateMethod",
+            returnTypeJava = "void",
+            visibility = Visibility.PRIVATE
+        ),
+        TestMethod(
+            name = "calculateSum",
+            returnTypeJava = "double",
+            arguments = listOf(
+                TestVariable(
+                    name = "a",
+                    javaType = "double",
+                ),
+                TestVariable(
+                    name = "b",
+                    javaType = "double",
+                ),
+            ),
+            visibility = Visibility.PUBLIC
+        ),
+        TestMethod(
+            name = "getString",
+            returnTypeJava = "String",
+            arguments = listOf(
+                TestVariable(
+                    name = "string",
+                    javaType = "String",
+                ),
+            ),
+            visibility = Visibility.PRIVATE
+        ),
+        TestMethod(
+            name = "processList",
+            returnTypeJava = "List",
+            arguments = listOf(
+                TestVariable(
+                    name = "list",
+                    javaType = "List"
+                ),
+            ),
+            visibility = Visibility.PUBLIC
+        ),
+    )
+)

--- a/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/java/TestJavaClass.kt
+++ b/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/java/TestJavaClass.kt
@@ -81,11 +81,13 @@ val javaClassTestClass = TestClass(
         TestMethod(
             name = "publicMethod",
             returnTypeJava = "void",
+            arguments = emptyList(),
             visibility = Visibility.PUBLIC
         ),
         TestMethod(
             name = "privateMethod",
             returnTypeJava = "void",
+            arguments = emptyList(),
             visibility = Visibility.PRIVATE
         ),
         TestMethod(

--- a/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/java/TestJavaClass.kt
+++ b/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/java/TestJavaClass.kt
@@ -15,25 +15,25 @@ val javaClassTestClass = TestClass(
             javaType = "int",
             value = "1",
             visibility = Visibility.PUBLIC,
-            mutability = VariableMutability.VAL,
+            isFinal = true,
             isInPrimaryConstructor = false,
-            isConst = true
+            isStatic = true
         ),
         TestVariable(
             name = "PRIVATE_CONSTANT",
             javaType = "int",
             value = "2",
             visibility = Visibility.PRIVATE,
-            mutability = VariableMutability.VAL,
+            isFinal = true,
             isInPrimaryConstructor = false,
-            isConst = true
+            isStatic = true
         ),
         TestVariable(
             name = "publicStaticVar",
             javaType = "int",
             value = "3",
             visibility = Visibility.PUBLIC,
-            mutability = VariableMutability.VAR,
+            isFinal = false,
             isInPrimaryConstructor = false,
             isStatic = true
         ),
@@ -42,7 +42,7 @@ val javaClassTestClass = TestClass(
             javaType = "int",
             value = "4",
             visibility = Visibility.PRIVATE,
-            mutability = VariableMutability.VAR,
+            isFinal = false,
             isInPrimaryConstructor = false,
             isStatic = true
         ),
@@ -51,30 +51,36 @@ val javaClassTestClass = TestClass(
             javaType = "String",
             value = "publicVar",
             visibility = Visibility.PUBLIC,
-            mutability = VariableMutability.VAR,
+            isFinal = false,
             isInPrimaryConstructor = false,
+            isStatic = false
         ),
         TestVariable(
             name = "privateVar",
             javaType = "String",
             value = "privateVar",
             visibility = Visibility.PRIVATE,
-            mutability = VariableMutability.VAR,
+            isFinal = false,
             isInPrimaryConstructor = false,
+            isStatic = false
         ),
         TestVariable(
             name = "customClass",
             javaType = "CustomJavaClass",
+            value = null,
             visibility = Visibility.PUBLIC,
-            mutability = VariableMutability.VAR,
+            isFinal = false,
             isInPrimaryConstructor = false,
+            isStatic = false
         ),
         TestVariable(
             name = "primaryConstructorVar",
             javaType = "String",
+            value = null,
             visibility = Visibility.PUBLIC,
-            mutability = VariableMutability.VAR,
+            isFinal = false,
             isInPrimaryConstructor = true,
+            isStatic = false
         ),
     ),
     customMethods = listOf(

--- a/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/sam/Sam.kt
+++ b/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/sam/Sam.kt
@@ -16,7 +16,7 @@ val mySamInterfaceTestClass = TestClass(
     customMethods = listOf(
         TestMethod(
             "samMethod",
-            TestKotlinType(
+            returnType = TestKotlinType(
                 "List",
                 params = listOf("java.lang.string")
             ),


### PR DESCRIPTION
I redefined the constructors so as not to write unnecessary arguments in Java tests: in class `TestMethod` we don't need `returnType: TestKotlinType?` and `hasGeneratedPartInName`, in class `TestVariable` we don't need `kotlinType` and we use argument `isFinal` to determine argument `mutability`, I also redefined another constructor for the case when the variable is an argument and we only need the `name` and `javaType`.