### PR TITLE
Fix getAbbreviation function

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.jetbrains.academy.test.system"
-version = "2.1.2"
+version = "2.1.3"
 
 allprojects {
     apply {

--- a/core/src/main/kotlin/org/jetbrains/academy/test/system/core/KTypeUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/academy/test/system/core/KTypeUtils.kt
@@ -42,29 +42,14 @@ private fun KType.checkAbbreviation(abbreviation: String, errorMessagePrefix: St
     Assertions.assertEquals(
         this.getAbbreviation(),
         abbreviation,
-        "The return type for $errorMessagePrefix must contain $abbreviation"
+        "The return type for $errorMessagePrefix must be $abbreviation"
     )
 }
 
 private fun KType.getAbbreviation(): String {
-    val separator = " /*"
-    val strRepresentation = this.toString()
-    if (separator !in strRepresentation) {
-        if (arguments.isNotEmpty()) {
-            this.arguments.first().type?.toString()?.let {
-                return it
-            }
-        }
-        return if ("?" in strRepresentation) {
-            strRepresentation.dropLast(1)
-        } else {
-            strRepresentation
-        }
-    }
-    val abr = strRepresentation.split(separator).first()
-    return if ("<" in strRepresentation) {
-        "$abr>"
-    } else {
-        abr
-    }
+    val hintRegex = Regex(""" /\*[\w>.<, =_]+ \*/""")
+    return this
+        .toString()
+        .replace(hintRegex, "")
+        .filterNot { it == '?' }
 }

--- a/core/src/test/kotlin/org/jetbrains/academy/test/system/core/AbbreviationTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/academy/test/system/core/AbbreviationTests.kt
@@ -1,0 +1,28 @@
+package org.jetbrains.academy.test.system.core
+
+import org.jetbrains.academy.test.system.core.models.classes.TestClass
+import org.jetbrains.academy.test.system.core.testData.abbreviation.*
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.Arguments
+
+class AbbreviationTests {
+    companion object {
+        @JvmStatic
+        fun testData() = listOf(
+            Arguments.of(withNullableTestClass),
+            Arguments.of(withTypeAliasTestClass),
+            Arguments.of(withGenericTypeAliasTestClass),
+            Arguments.of(withDoubleTypeAliasTestClass),
+            Arguments.of(withNullableGenericParametersTestClass)
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("testData")
+    fun testAbbreviation(testClass: TestClass) {
+        val clazz = testClass.checkBaseDefinition()
+        testClass.checkFieldsDefinition(clazz)
+        testClass.checkDeclaredMethods(clazz)
+    }
+}

--- a/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/abbreviation/WithDoubleTypeAlias.kt
+++ b/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/abbreviation/WithDoubleTypeAlias.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.academy.test.system.core.testData.abbreviation
+
+import org.jetbrains.academy.test.system.core.models.TestKotlinType
+import org.jetbrains.academy.test.system.core.models.Visibility
+import org.jetbrains.academy.test.system.core.models.classes.TestClass
+import org.jetbrains.academy.test.system.core.models.variable.TestVariable
+import org.jetbrains.academy.test.system.core.models.variable.VariableMutability
+
+val identifierMapKotlinType = TestKotlinType(
+    "Map",
+    "kotlin.collections.Map<org.jetbrains.academy.test.system.core.testData.abbreviation.Identifier, org.jetbrains.academy.test.system.core.testData.abbreviation.Identifier>"
+)
+
+val withDoubleTypeAliasTestClass = TestClass(
+    "WithDoubleTypeAlias",
+    "org.jetbrains.academy.test.system.core.testData.abbreviation",
+    declaredFields = listOf(
+        TestVariable(
+            name = "value",
+            javaType = "Map",
+            kotlinType = identifierMapKotlinType,
+            visibility = Visibility.PUBLIC,
+            mutability = VariableMutability.VAL
+        )
+    )
+)
+
+typealias Identifier = Int
+
+@Suppress("unused")
+data class WithDoubleTypeAlias(val value: Map<Identifier, Identifier>)

--- a/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/abbreviation/WithGenericTypeAlias.kt
+++ b/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/abbreviation/WithGenericTypeAlias.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.academy.test.system.core.testData.abbreviation
+
+import org.jetbrains.academy.test.system.core.models.TestKotlinType
+import org.jetbrains.academy.test.system.core.models.Visibility
+import org.jetbrains.academy.test.system.core.models.classes.TestClass
+import org.jetbrains.academy.test.system.core.models.variable.TestVariable
+import org.jetbrains.academy.test.system.core.models.variable.VariableMutability
+
+val dictionaryTestKotlinType = TestKotlinType(
+    "Map<String, String>",
+    "org.jetbrains.academy.test.system.core.testData.abbreviation.Dictionary<kotlin.String>"
+)
+
+val withGenericTypeAliasTestClass = TestClass(
+    "WithGenericTypeAlias",
+    "org.jetbrains.academy.test.system.core.testData.abbreviation",
+    declaredFields = listOf(
+        TestVariable(
+            name = "value",
+            javaType = "Map",
+            kotlinType = dictionaryTestKotlinType,
+            visibility = Visibility.PUBLIC,
+            mutability = VariableMutability.VAL
+        )
+    )
+)
+
+typealias Dictionary<T> = Map<String, T>
+
+@Suppress("unused")
+data class WithGenericTypeAlias(val value: Dictionary<String>)

--- a/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/abbreviation/WithNullable.kt
+++ b/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/abbreviation/WithNullable.kt
@@ -1,0 +1,27 @@
+package org.jetbrains.academy.test.system.core.testData.abbreviation
+
+import org.jetbrains.academy.test.system.core.models.TestKotlinType
+import org.jetbrains.academy.test.system.core.models.Visibility
+import org.jetbrains.academy.test.system.core.models.classes.TestClass
+import org.jetbrains.academy.test.system.core.models.variable.TestVariable
+import org.jetbrains.academy.test.system.core.models.variable.VariableMutability
+
+val withNullableTestClass = TestClass(
+    "WithNullable",
+    "org.jetbrains.academy.test.system.core.testData.abbreviation",
+    declaredFields = listOf(
+        TestVariable(
+            name = "name",
+            javaType = "String",
+            kotlinType = TestKotlinType("String?",
+                "kotlin.String",
+                isNullable = true
+            ),
+            visibility = Visibility.PUBLIC,
+            mutability = VariableMutability.VAL
+        )
+    )
+)
+
+@Suppress("unused")
+data class WithNullable(val name: String?)

--- a/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/abbreviation/WithNullableGenericParameters.kt
+++ b/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/abbreviation/WithNullableGenericParameters.kt
@@ -1,0 +1,29 @@
+package org.jetbrains.academy.test.system.core.testData.abbreviation
+
+import org.jetbrains.academy.test.system.core.models.TestKotlinType
+import org.jetbrains.academy.test.system.core.models.Visibility
+import org.jetbrains.academy.test.system.core.models.classes.TestClass
+import org.jetbrains.academy.test.system.core.models.variable.TestVariable
+import org.jetbrains.academy.test.system.core.models.variable.VariableMutability
+
+val nullableStringMapKotlinType = TestKotlinType(
+    "Map",
+    "kotlin.collections.Map<kotlin.String, kotlin.String>",
+)
+
+val withNullableGenericParametersTestClass = TestClass(
+    "WithNullableGenericParameters",
+    "org.jetbrains.academy.test.system.core.testData.abbreviation",
+    declaredFields = listOf(
+        TestVariable(
+            name = "value",
+            javaType = "Map",
+            kotlinType = nullableStringMapKotlinType,
+            visibility = Visibility.PUBLIC,
+            mutability = VariableMutability.VAL
+        )
+    )
+)
+
+@Suppress("unused")
+data class WithNullableGenericParameters(val value: Map<String?, String?>)

--- a/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/abbreviation/WithTypeAlias.kt
+++ b/core/src/test/kotlin/org/jetbrains/academy/test/system/core/testData/abbreviation/WithTypeAlias.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.academy.test.system.core.testData.abbreviation
+
+import org.jetbrains.academy.test.system.core.models.TestKotlinType
+import org.jetbrains.academy.test.system.core.models.Visibility
+import org.jetbrains.academy.test.system.core.models.classes.TestClass
+import org.jetbrains.academy.test.system.core.models.variable.TestVariable
+import org.jetbrains.academy.test.system.core.models.variable.VariableMutability
+
+val typeAliasTestKotlinType = TestKotlinType(
+    "String",
+    "org.jetbrains.academy.test.system.core.testData.abbreviation.TypeAlias"
+)
+
+val withTypeAliasTestClass = TestClass(
+    "WithTypeAlias",
+    "org.jetbrains.academy.test.system.core.testData.abbreviation",
+    declaredFields = listOf(
+        TestVariable(
+            name = "name",
+            javaType = "String",
+            kotlinType = typeAliasTestKotlinType,
+            visibility = Visibility.PUBLIC,
+            mutability = VariableMutability.VAL
+        )
+    )
+)
+
+typealias TypeAlias = String
+
+@Suppress("unused")
+data class WithTypeAlias(val name: TypeAlias)


### PR DESCRIPTION
As of right now, the behavior of getAbbreviation is pretty random, so it needs to be fixed. Anyway, getAbbrevaition is only used in checkAbbreviation, which compares it to the manually given abbreviation. Therefore, the exact behavior doesn’t influence much